### PR TITLE
Restore original par settings upon exiting function.

### DIFF
--- a/R/sample_filtering.R
+++ b/R/sample_filtering.R
@@ -254,7 +254,8 @@ metric_sample_filter = function(expr, nreads = colSums(expr), ralign = NULL,
 
       is_bad = rep(FALSE,dim(expr)[2])
 
-      par(mfcol = c(criterion_count,2))
+      op <- par(mfcol = c(criterion_count,2))
+      on.exit(par(op))
 
       if(!is.null(nreads)){
         is_bad = filtered_nreads
@@ -417,8 +418,9 @@ factor_sample_filter = function(expr, qual, gene_filter = NULL, max_exp_pcs = 5,
   num_qual_pcs = which(csum > min_qual_variance)[1]
 
   if(plot){
+    op <- par(mfrow = c(2,1))
+    on.exit(par(op))
     for (i in 1:num_qual_pcs){
-      par(mfrow = c(2,1))
       hist(qpc$x[,i],breaks = hist_breaks, main = paste0("Distribution of Quality PC ",i), xlab = paste0("Qual PC",i))
       barplot(abs(qpc$rotation[,i]),col = c("red","green")[1 + (qpc$rotation[,i] > 0)], cex.names = .25,horiz = T, las=1, main = "Loadings")
     }


### PR DESCRIPTION
The functions `metric_sample_filter` and `factor_sample_filter` have the side effect of modifying the `par` settings. This PR restores the original par settings upon exiting these functions. The code below demonstrates the side effects:

```
devtools::install_github("drisso/bioc2016singlecell")
devtools::install_github("YosefLab/scone@develop")
library("bioc2016singlecell")
library("scone")

data("ws_input")
par("mfrow")
# [1] 1 1
mfilt_report <- metric_sample_filter(expr = counts,
                                     nreads = qc$NREADS,ralign = qc$RALIGN,
                                     suff_nreads = 10^5,
                                     suff_ralign = 90,
                                     pos_controls = hk,
                                     zcut = 3,mixture = FALSE, plot = TRUE)
par("mfrow")
# [1] 3 2
x <- factor_sample_filter(expr = counts, qual = qc, plot = TRUE)
par("mfrow")
# [1] 1 2
```
