### PR TITLE
BUG FIX: if (rezero) { } was called with length(rezero) > 1

### DIFF
--- a/R/scone_main.R
+++ b/R/scone_main.R
@@ -172,11 +172,11 @@ setMethod(
                         return_norm = c("no", "in_memory", "hdf5"),
                         hdf5file,
                         bpparam=BiocParallel::bpparam()) {
-    
-    
-    rezero = (zero %in% c("preadjust","strong"))
-    fixzero = (zero %in% c("postadjust","strong"))
-    
+
+    zero <- match.arg(zero)
+    rezero <- (zero %in% c("preadjust","strong"))
+    fixzero <- (zero %in% c("postadjust","strong"))
+
     if(x@is_log) {
       stop("At the moment, scone is implemented only for non-log counts.")
     }


### PR DESCRIPTION
Because
```r
Running examples in ‘scone-Ex.R’ failed
The error most likely occurred in:

> ### Name: biplot_interactive
> ### Title: Interactive biplot
> ### Aliases: biplot_interactive
> 
> ### ** Examples
> 
> mat <- matrix(rpois(1000, lambda = 5), ncol=10)
> colnames(mat) <- paste("X", 1:ncol(mat), sep="")
> obj <- SconeExperiment(mat)
> res <- scone(obj, scaling=list(none=identity,
+    uq=UQ_FN, deseq=DESEQ_FN,  fq=FQT_FN),
+ evaluate=TRUE, k_ruv=0, k_qc=0, eval_kclust=2,
+    bpparam = BiocParallel::SerialParam())
Error in if (rezero) { : the condition has length > 1
Calls: scone -> scone -> .local
Execution halted
```